### PR TITLE
fix: resolve scroll issue on Flutter Web & WebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.7
+
+* **Fixed Scroll Issue on Flutter Web & WebView** ([#3](https://github.com/sheriax/flutter_stripe_connect/issues/3))
+  - Added `overflow: auto` to web component container so Stripe content scrolls properly on Flutter Web
+  - Added default `gestureRecognizers` (vertical + horizontal drag) to `StripeConnectWebView` so scroll gestures pass through to the WebView on mobile
+  - `gestureRecognizers` now correctly forwarded in `useWebView` mode for all components
+
 ## 0.3.6
 
 * **Updated iOS Dependency** - Pinned `StripeConnect` dependency to `~> 25.0`

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.5"
+    version: "0.3.6"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/widgets/connect_components.dart
+++ b/lib/src/widgets/connect_components.dart
@@ -89,6 +89,7 @@ class StripeAccountOnboarding extends StatelessWidget {
           onLoaded: onLoaded,
           onLoadError: onLoadError,
           onExit: onExit,
+          gestureRecognizers: gestureRecognizers,
         );
       }
       onLoadError?.call(
@@ -154,6 +155,7 @@ class StripeAccountManagement extends StatelessWidget {
           componentPath: StripeConnectPaths.accountManagement,
           onLoaded: onLoaded,
           onLoadError: onLoadError,
+          gestureRecognizers: gestureRecognizers,
         );
       }
       onLoadError?.call(
@@ -230,6 +232,7 @@ class StripePayouts extends StatelessWidget {
           componentPath: StripeConnectPaths.payouts,
           onLoaded: onLoaded,
           onLoadError: onLoadError,
+          gestureRecognizers: gestureRecognizers,
         );
       }
       onLoadError?.call(
@@ -292,6 +295,7 @@ class StripePayments extends StatelessWidget {
           componentPath: StripeConnectPaths.payments,
           onLoaded: onLoaded,
           onLoadError: onLoadError,
+          gestureRecognizers: gestureRecognizers,
         );
       }
       onLoadError?.call(

--- a/lib/src/widgets/web_components.dart
+++ b/lib/src/widgets/web_components.dart
@@ -75,7 +75,8 @@ class _StripeConnectWebViewState extends State<StripeConnectWebView> {
           ..width = '100%'
           ..height = '100%'
           ..display = 'flex'
-          ..flexDirection = 'column';
+          ..flexDirection = 'column'
+          ..overflow = 'auto';
 
         // Schedule component creation after the container is added to DOM
         _createComponentAsync(container);

--- a/lib/src/widgets/webview_components.dart
+++ b/lib/src/widgets/webview_components.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import '../models/webview_config.dart';
@@ -82,6 +84,11 @@ class StripeConnectWebView extends StatefulWidget {
   /// Extra query parameters to pass to the URL
   final Map<String, String>? extraParams;
 
+  /// Set of gesture recognizers to forward to the WebView.
+  /// If not provided, defaults to vertical and horizontal drag recognizers
+  /// to enable scrolling within the WebView content.
+  final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
+
   const StripeConnectWebView({
     super.key,
     required this.componentPath,
@@ -91,6 +98,7 @@ class StripeConnectWebView extends StatefulWidget {
     this.onExit,
     this.onClose,
     this.extraParams,
+    this.gestureRecognizers,
   });
 
   @override
@@ -256,7 +264,16 @@ class _StripeConnectWebViewState extends State<StripeConnectWebView> {
 
     return Stack(
       children: [
-        WebViewWidget(controller: _controller),
+        WebViewWidget(
+          controller: _controller,
+          gestureRecognizers: widget.gestureRecognizers ??
+              <Factory<OneSequenceGestureRecognizer>>{
+                Factory<VerticalDragGestureRecognizer>(
+                    () => VerticalDragGestureRecognizer()),
+                Factory<HorizontalDragGestureRecognizer>(
+                    () => HorizontalDragGestureRecognizer()),
+              },
+        ),
         if (_isLoading) const Center(child: CircularProgressIndicator()),
       ],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_stripe_connect
 description: >
   Flutter plugin for Stripe Connect embedded components. Embed account onboarding,
   account management, payouts, and payments UI in your Flutter app.
-version: 0.3.6
+version: 0.3.7
 homepage: https://github.com/sheriax/flutter_stripe_connect
 repository: https://github.com/sheriax/flutter_stripe_connect
 issue_tracker: https://github.com/sheriax/flutter_stripe_connect/issues


### PR DESCRIPTION
## Fixes #3

### Problem
Stripe Connect components (e.g. `StripeAccountOnboarding`) render properly but **cannot be scrolled**, cutting off content.

### Root Cause
Two separate issues depending on the platform path:

1. **Flutter Web** (`HtmlElementView`) — The container `div` had `height: 100%` but no `overflow` property, so the browser clipped content instead of scrolling.
2. **WebView mode** (mobile) — `WebViewWidget` was rendered without `gestureRecognizers`, so Flutter's gesture arena consumed vertical drag gestures instead of forwarding them to the WebView.

### Changes
- **`web_components.dart`** — Added `overflow: auto` to the container div
- **`webview_components.dart`** — Added `gestureRecognizers` parameter with defaults (`VerticalDragGestureRecognizer` + `HorizontalDragGestureRecognizer`)
- **`connect_components.dart`** — Forward `gestureRecognizers` through `useWebView` code paths
- **Version bump** to 0.3.7